### PR TITLE
Bug fix fixing name in discord message output

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,7 +303,7 @@ function speak_impl(voice_Connection, mapKey) {
                 let new_buffer = await convert_audio(buffer)
                 let out = await transcribe(new_buffer);
                 if (out != null)
-                    process_commands_query(out, mapKey, user.id);
+                    process_commands_query(out, mapKey, user);
             } catch (e) {
                 console.log('tmpraw rename: ' + e)
             }


### PR DESCRIPTION
A bug on my end hosting directly on a digital ocean droplet caused every name to be given as undefined.
The following change fixed the problem entirely, and it seems to work as intended now.

![image](https://user-images.githubusercontent.com/10059450/106391594-7f0f2f80-63ee-11eb-8484-fe55cf88b4a5.png)
